### PR TITLE
Added tests, list down below. Check 4 in PR #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs
 output/*
+__pycache__

--- a/test_generate.py
+++ b/test_generate.py
@@ -1,12 +1,30 @@
 import unittest
 import generate
 import filecmp
+import os
+from unittest import mock
 
 class TestGenerate(unittest.TestCase):
 	def test_generate_site_from_example(self):
-		result = generate.generate_site("test/source", "output")
-		self.assertTrue(filecmp.cmp("output/index.html", "test/expected_output/index.html"), "Test fail: Unexpected output in index.html")
-		self.assertTrue(filecmp.cmp("output/contact.html", "test/expected_output/contact.html"), "Test fail: Unexpected output in contact.html")
+		source_dir = "test/source"
+		expected_dir = "test/expected_output"
+		output_dir = "output"
+		result = generate.generate_site(source_dir, output_dir)
+
+		# for each file which we expect
+		for f in os.listdir(expected_dir):
+			outputted_file = os.path.join(output_dir, f)
+			# make sure that the file actually got created
+			self.assertTrue(os.path.isfile(outputted_file), "File " + f + " did not get created!")
+			# make sure that the file contents are identical
+			self.assertTrue(filecmp.cmp(outputted_file, os.path.join(expected_dir, f)), "Test fail: Unexpected output in " + f)
+
+	#@mock.patch('generate.read_file')
+	#def test_reading(self, read_file_mock):
+	#	with open("example.rst", "w") as f:
+	#		f.write('{"title": "example", "layout": "example.html"} --- content example here')
+
+
 
 # to be able to just run `python test_generate.py` directly
 if __name__ == '__main__':

--- a/test_generate.py
+++ b/test_generate.py
@@ -6,6 +6,17 @@ import shutil
 from unittest import mock
 
 class TestGenerate(unittest.TestCase):
+
+	def setUp(self):
+		self.input = "testin"
+		self.output = "testout"
+		os.mkdir(self.input)
+		os.mkdir(self.output)
+
+	def tearDown(self):
+		shutil.rmtree(self.input)
+		shutil.rmtree(self.output)
+
 	def test_generate_site_from_example(self):
 		source_dir = "test/source"
 		expected_dir = "test/expected_output"
@@ -20,48 +31,33 @@ class TestGenerate(unittest.TestCase):
 			# make sure that the file contents are identical
 			self.assertTrue(filecmp.cmp(outputted_file, os.path.join(expected_dir, f)), "Test fail: Unexpected output in " + f)
 
-	def prep_test(self, test_location):
-		if not os.path.exists(test_location):
-			os.mkdir(test_location)
-		else:
-			print(test_location + " already exists. aborting...")
-			quit()
-
 	def test_list_files(self):
-		test_location = "test_listing"
-		self.prep_test(test_location)
-
 		for i in range(1, 15):
 			if i % 2 == 0:
 				# create some non-rst files too
-				with open(os.path.join(test_location, "nonrst_file_" + str(i)), "w") as f:
+				with open(os.path.join(self.output, "nonrst_file_" + str(i)), "w") as f:
 					pass
 			# create 15 rst files
-			with open(os.path.join(test_location, "test_file_" + str(i) + ".rst"), "w") as f:
+			with open(os.path.join(self.output, "test_file_" + str(i) + ".rst"), "w") as f:
 				pass
 
 		num_rst = 0
-		for file, basename in generate.list_files(test_location):
+		for file, basename in generate.list_files(self.output):
 			num_rst += 1
-		# get rid of the directory when we're done counting
-		shutil.rmtree(test_location)
+
 		self.assertTrue(num_rst == i, "Test fail: list_files() fails to list correct number of .rst files")
 
 	def test_write_output(self):
-		test_location = "test_out"
-		self.prep_test(test_location)
-
 		for i in range(1, 15):
-			generate.write_output(str(i), "content of html here", test_location)
+			generate.write_output(str(i), "content of html here", self.output)
 
-		for name in os.listdir(test_location):
-			f = open(os.path.join(test_location, name), 'r')
+		for name in os.listdir(self.output):
+			f = open(os.path.join(self.output, name), 'r')
 			self.assertTrue(f.read() == "content of html here", "Test fail: write_output() writes wrong content to files")
 			f.close()
 			base, ext = os.path.splitext(name)
 			self.assertTrue(ext == ".html", "Test fail: write_output() doesn't write .html files")
 
-		shutil.rmtree(test_location)
 # to be able to just run `python test_generate.py` directly
 if __name__ == '__main__':
 	unittest.main()

--- a/test_generate.py
+++ b/test_generate.py
@@ -20,10 +20,16 @@ class TestGenerate(unittest.TestCase):
 			# make sure that the file contents are identical
 			self.assertTrue(filecmp.cmp(outputted_file, os.path.join(expected_dir, f)), "Test fail: Unexpected output in " + f)
 
-	def test_list_files(self):
-		test_location = "test_listing"
+	def prep_test(self, test_location):
 		if not os.path.exists(test_location):
 			os.mkdir(test_location)
+		else:
+			print(test_location + " already exists. aborting...")
+			quit()
+
+	def test_list_files(self):
+		test_location = "test_listing"
+		self.prep_test(test_location)
 
 		for i in range(1, 15):
 			if i % 2 == 0:

--- a/test_generate.py
+++ b/test_generate.py
@@ -17,6 +17,34 @@ class TestGenerate(unittest.TestCase):
 		shutil.rmtree(self.input)
 		shutil.rmtree(self.output)
 
+	@mock.patch('generate.write_output')
+	def test_generate_site_no_layout_in_metadata(self, mock_call):
+		name = "empty_template.rst"
+		with open(os.path.join(self.input, name), 'w') as f:
+			f.write('''{"title": "Test"}
+					---
+					content''')
+		generate.generate_site(self.input, self.output)
+		self.assertFalse(mock_call.called, "Test fail: write_output() is called even if there is no template")
+
+	@mock.patch('generate.write_output')
+	def test_generate_site_invalid_template(self, mock_call):
+		name = "invalid_template.rst"
+		with open(os.path.join(self.input, name), 'w') as f:
+			f.write('''{"title": "title", "layout": "invalid"}
+				---
+				content''')
+		generate.generate_site(self.input, self.output)
+		self.assertFalse(mock_call.called, "Test fail: write_output() is called even if the template is invalid")
+
+	@mock.patch('generate.write_output')
+	def test_generate_site_empty(self, mock_call):
+		name = "empty.rst"
+		with open(os.path.join(self.input, name), 'w') as f:
+			f.write("{ }")
+		generate.generate_site(self.input, self.output)
+		self.assertFalse(mock_call.called, "Test fail: write_output() is called even if the metadata in rst file is empty")
+
 	def test_generate_site_from_example(self):
 		source_dir = "test/source"
 		expected_dir = "test/expected_output"

--- a/test_generate.py
+++ b/test_generate.py
@@ -1,0 +1,13 @@
+import unittest
+import generate
+import filecmp
+
+class TestGenerate(unittest.TestCase):
+	def test_generate_site_from_example(self):
+		result = generate.generate_site("test/source", "output")
+		self.assertTrue(filecmp.cmp("output/index.html", "test/expected_output/index.html"), "Test fail: Unexpected output in index.html")
+		self.assertTrue(filecmp.cmp("output/contact.html", "test/expected_output/contact.html"), "Test fail: Unexpected output in contact.html")
+
+# to be able to just run `python test_generate.py` directly
+if __name__ == '__main__':
+	unittest.main()

--- a/test_generate.py
+++ b/test_generate.py
@@ -47,6 +47,21 @@ class TestGenerate(unittest.TestCase):
 		shutil.rmtree(test_location)
 		self.assertTrue(num_rst == i, "Test fail: list_files() fails to list correct number of .rst files")
 
+	def test_write_output(self):
+		test_location = "test_out"
+		self.prep_test(test_location)
+
+		for i in range(1, 15):
+			generate.write_output(str(i), "content of html here", test_location)
+
+		for name in os.listdir(test_location):
+			f = open(os.path.join(test_location, name), 'r')
+			self.assertTrue(f.read() == "content of html here", "Test fail: write_output() writes wrong content to files")
+			f.close()
+			base, ext = os.path.splitext(name)
+			self.assertTrue(ext == ".html", "Test fail: write_output() doesn't write .html files")
+
+		shutil.rmtree(test_location)
 # to be able to just run `python test_generate.py` directly
 if __name__ == '__main__':
 	unittest.main()

--- a/test_generate.py
+++ b/test_generate.py
@@ -2,6 +2,7 @@ import unittest
 import generate
 import filecmp
 import os
+import shutil
 from unittest import mock
 
 class TestGenerate(unittest.TestCase):
@@ -19,12 +20,26 @@ class TestGenerate(unittest.TestCase):
 			# make sure that the file contents are identical
 			self.assertTrue(filecmp.cmp(outputted_file, os.path.join(expected_dir, f)), "Test fail: Unexpected output in " + f)
 
-	#@mock.patch('generate.read_file')
-	#def test_reading(self, read_file_mock):
-	#	with open("example.rst", "w") as f:
-	#		f.write('{"title": "example", "layout": "example.html"} --- content example here')
+	def test_list_files(self):
+		test_location = "test_listing"
+		if not os.path.exists(test_location):
+			os.mkdir(test_location)
 
+		for i in range(1, 15):
+			if i % 2 == 0:
+				# create some non-rst files too
+				with open(os.path.join(test_location, "nonrst_file_" + str(i)), "w") as f:
+					pass
+			# create 15 rst files
+			with open(os.path.join(test_location, "test_file_" + str(i) + ".rst"), "w") as f:
+				pass
 
+		num_rst = 0
+		for file, basename in generate.list_files(test_location):
+			num_rst += 1
+		# get rid of the directory when we're done counting
+		shutil.rmtree(test_location)
+		self.assertTrue(num_rst == i, "Test fail: list_files() fails to list correct number of .rst files")
 
 # to be able to just run `python test_generate.py` directly
 if __name__ == '__main__':


### PR DESCRIPTION
- Test for missing template (write_output shouldn't be called)

- Test for invalid template (write_output shouldn't be called)

- Test for no metadata provided (write_output shouldn't be called)

- Test that the expected output is generated

- Test that list_files() actually lists .rst files and doesn't care about non-.rst files

- Test that write_output() writes given content and appends .html extension

Note that the first three mentioned tests are failing at this time, as I forgot about this aspect when fixing the bugs lol

edit: all's good